### PR TITLE
fix: 修复Mac应用设置页面外部链接无法打开的问题

### DIFF
--- a/electron/main/ipc/app.ts
+++ b/electron/main/ipc/app.ts
@@ -19,6 +19,10 @@ function setupIpcHandlers() {
     shell.openPath(app.getPath('logs'))
   })
 
+  typedIpcMainHandle(IPC_CHANNELS.app.openExternal, (_, url: string) => {
+    shell.openExternal(url)
+  })
+
   typedIpcMainHandle(IPC_CHANNELS.account.switch, (_, { account }) => {
     accountManager.setAccountName(account.id, account.name)
   })

--- a/shared/electron-api.d.ts
+++ b/shared/electron-api.d.ts
@@ -119,6 +119,7 @@ export interface IpcChannels {
 
   // App
   [IPC_CHANNELS.app.openLogFolder]: () => void
+  [IPC_CHANNELS.app.openExternal]: (url: string) => void
   [IPC_CHANNELS.app.notifyUpdate]: (arg: {
     currentVersion: string
     latestVersion: string

--- a/shared/ipcChannels.ts
+++ b/shared/ipcChannels.ts
@@ -68,5 +68,6 @@ export const IPC_CHANNELS = {
   app: {
     openLogFolder: 'app:openLogFolder',
     notifyUpdate: 'app:notifyUpdate',
+    openExternal: 'app:openExternal',
   },
 } as const

--- a/src/pages/SettingsPage/components/OtherSetting.tsx
+++ b/src/pages/SettingsPage/components/OtherSetting.tsx
@@ -9,6 +9,20 @@ export function OtherSetting() {
     await window.ipcRenderer.invoke(IPC_CHANNELS.app.openLogFolder)
   }
 
+  const handleOpenGitHub = async () => {
+    await window.ipcRenderer.invoke(
+      IPC_CHANNELS.app.openExternal,
+      'https://github.com/qiutongxue/oba-live-tool',
+    )
+  }
+
+  const handleOpenIssues = async () => {
+    await window.ipcRenderer.invoke(
+      IPC_CHANNELS.app.openExternal,
+      'https://github.com/qiutongxue/oba-live-tool/issues',
+    )
+  }
+
   return (
     <Card>
       <CardHeader>
@@ -34,27 +48,15 @@ export function OtherSetting() {
               <p className="text-sm text-muted-foreground">了解更多项目相关内容</p>
             </div>
             <div className="flex gap-2">
-              <Button variant="outline" size="sm" className="gap-2" asChild>
-                <a
-                  href="https://github.com/qiutongxue/oba-live-tool"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <SimpleIconsGithub className="h-4 w-4" />
-                  GitHub
-                  <ExternalLinkIcon className="h-4 w-4" />
-                </a>
+              <Button variant="outline" size="sm" className="gap-2" onClick={handleOpenGitHub}>
+                <SimpleIconsGithub className="h-4 w-4" />
+                GitHub
+                <ExternalLinkIcon className="h-4 w-4" />
               </Button>
-              <Button variant="outline" size="sm" className="gap-2" asChild>
-                <a
-                  href="https://github.com/qiutongxue/oba-live-tool/issues"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <BugIcon className="h-4 w-4" />
-                  反馈问题
-                  <ExternalLinkIcon className="h-4 w-4" />
-                </a>
+              <Button variant="outline" size="sm" className="gap-2" onClick={handleOpenIssues}>
+                <BugIcon className="h-4 w-4" />
+                反馈问题
+                <ExternalLinkIcon className="h-4 w-4" />
               </Button>
             </div>
           </div>


### PR DESCRIPTION
## 问题描述
在 Mac Electron 应用中，设置页面的 GitHub 和反馈问题按钮点击无响应。

## 问题原因
1. 在 Electron 应用中，直接使用 `<a>` 标签的 `href` 属性无法打开外部链接
2. 缺少相应的 IPC 通道来处理外部链接打开

## 修复内容
- ✅ 添加 `app:openExternal` IPC 通道用于打开外部链接
- ✅ 在主进程中实现 `shell.openExternal` 处理
- ✅ 将 `<a>` 标签改为 `Button` 组件，使用 `onClick` 事件通过 IPC 调用打开链接
- ✅ 更新相关类型定义

## 测试
修复后，在构建的 Mac Electron 应用中点击设置页面的 "GitHub" 和 "反馈问题" 按钮能够正常打开对应的网页。

## 文件变更
- `shared/ipcChannels.ts` - 添加 openExternal IPC 通道
- `electron/main/ipc/app.ts` - 实现外部链接打开处理
- `shared/electron-api.d.ts` - 更新类型定义
- `src/pages/SettingsPage/components/OtherSetting.tsx` - 修复按钮点击事件