### PR TITLE
fix(自动回复): 修复设置页所有按钮点击无反应的问题

### DIFF
--- a/src/hooks/useAutoReplyConfig.ts
+++ b/src/hooks/useAutoReplyConfig.ts
@@ -1,3 +1,4 @@
+import { current } from 'immer'
 import { create } from 'zustand'
 import { createJSONStorage, persist } from 'zustand/middleware'
 import { immer } from 'zustand/middleware/immer'
@@ -147,7 +148,10 @@ export const useAutoReplyConfigStore = create<AutoReplyConfigStore>()(
         updateConfig: (accountId, configUpdates) =>
           set(state => {
             const context = ensureContext(state, accountId)
-            const newConfig = mergeWithoutArray(context.config, configUpdates)
+            // context.config 是 immer 的 draft（Proxy），不能直接交给 lodash 的
+            // mergeWith 遍历——immer 11 会因触发 Proxy 不变量而抛错（读取 prototype）。
+            // 先用 current() 取一份纯对象快照再合并。
+            const newConfig = mergeWithoutArray(current(context.config), configUpdates)
             context.config = newConfig
           }),
       }


### PR DESCRIPTION
updateConfig 在 immer 的 set 回调里，把 immer draft（Proxy）直接传给了 lodash 的 mergeWith 做深度合并。immer 11 严格执行 V8 Proxy 不变量， lodash 遍历时探测 draft 的 prototype 会抛出 TypeError，且异常发生在 setState 通知订阅者之前，导致 React 不重渲染——表现为设置页每个控件
都能点击但毫无反应。

改为先用 current() 取草稿的纯对象快照再交给 mergeWith，保留原有深度
合并语义的同时避开 Proxy 触发点。

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
