### PR TITLE
docs: 修复 README 中失效的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ AI 助手只支持文本对话，在使用 AI 助手功能前，请先设置好�
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=qiutongxue/oba-live-tool&type=Date)](https://www.star-history.com/#qiutongxue/oba-live-tool&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=qiutongxue/oba-live-tool&type=Date)](https://star-history.dera.page/#qiutongxue/oba-live-tool&Date)
 
 <!-- badage -->
 


### PR DESCRIPTION
当前 README 中的 Star History 图表已经失效，原因在于 GitHub stargazer API 的限制导致原有数据源无法正常返回数据。

此次改动将 Star History 图表迁移到新的数据源，无需 API token 即可正常展示仓库的 star 历史曲线，确保 README 中的图表恢复可用。